### PR TITLE
Add our DNSimple billing contact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: OpenTofu Plan
         env:
           GITHUB_TOKEN: ${{ secrets.TF_GH_TOKEN }}
-        run: tofu plan -no-color -var-file .tfvars -detailed-exitcode 
+          DNSIMPLE_ACCOUNT: ${{ secrets.TF_DNSIMPLE_ACCOUNT }}
+          DNSIMPLE_TOKEN: ${{ secrets.TF_DNSIMPLE_TOKEN }}
+        run: tofu plan -no-color -var-file .tfvars -detailed-exitcode
 
   trivy:
     name: Trivy

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,6 +1,49 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/hashicorp/dnsimple" {
+  version = "1.5.0"
+  hashes = [
+    "h1:0MRrmtqKQlpFHRzrtvqalbxCWWCf+S4dqYGnN5qJUZE=",
+    "zh:1e2f64e7a5e7eeaff595372e31007f43475c889f29cdf47995ebb22bc74022f1",
+    "zh:2158a2c4a4bbdc9f6de3811509f0fc3ea25b75914e5ba8ece1f5f63387951ea9",
+    "zh:27956bc5f75678c025c621caed014a9f6704e8c1d5cd93ab7b66e376c91debec",
+    "zh:3dbfacce8bf7b83f3abec6f335c46768164a51977970318df12c0b21c1af1d2f",
+    "zh:570bdf670185b933bcb18c706341497656782a8832db0ab54a4eb77813d63261",
+    "zh:5fd9a13824fdc5d4679f3fb9537027bd77a9b6a792a0cfe4c3c2080e1de95044",
+    "zh:8d4042bbd2ab3a65f7b0ff1f51932b0daa4cec4c7263aa608694b3bac3aaceaa",
+    "zh:953da1f55f360ac9c9dca6f3ccaf15a85a38b4184c5d79ead0f413e92a0f32c1",
+    "zh:a1a71deb18f56c8bf0c4b19a07fc6b15d1b354a2aeb7be1d994e719f46cb5c13",
+    "zh:ad7e71fa6f0b9292a2e28e7362bba6112fca6609653250cce313c9231bff9b7a",
+    "zh:dabd9e63d208e5e0dc8e990d21bc3645998e1f42be6583de188eb21764dbadad",
+    "zh:dbe9a309f3bdd26faa7d0c009f7ad50c2de2e98facafdc00d065009392d95de8",
+    "zh:dbf452a7bb638122c959a91f7df891fc8926b524f1ea2de50f71bf8751e6cfe8",
+    "zh:e3f485af6712f5fb1760463492058ddaf798f04ce521a2d9e2a2f5b984b520e6",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.opentofu.org/hashicorp/github" {
+  version = "6.2.1"
+  hashes = [
+    "h1:uDerb9YJo3vAO+wKw+Z064InX5aXom+nKLDry2eGf14=",
+    "zh:172aa5141c525174f38504a0d2e69d0d16c0a0b941191b7170fe6ae4d7282e30",
+    "zh:1a098b731fa658c808b591d030cc17cc7dfca1bf001c3c32e596f8c1bf980e9f",
+    "zh:245d6a1c7e632d8ae4bdd2da2516610c50051e81505cf420a140aa5fa076ea90",
+    "zh:43c61c230fb4ed26ff1b04b857778e65be3d8f80292759abbe2a9eb3c95f6d97",
+    "zh:59bb7dd509004921e4322a196be476a2f70471b462802f09d03d6ce96f959860",
+    "zh:5cb2ab8035d015c0732107c109210243650b6eb115e872091b0f7b98c2763777",
+    "zh:69d2a6acfcd686f7e859673d1c8a07fc1fc1598a881493f19d0401eb74c0f325",
+    "zh:77f36d3f46911ace5c50dee892076fddfd64a289999a5099f8d524c0143456d1",
+    "zh:87df41097dfcde72a1fbe89caca882af257a4763c2e1af669c74dcb8530f9932",
+    "zh:899dbe621f32d58cb7c6674073a6db8328a9db66eecfb0cc3fc13299fd4e62e7",
+    "zh:ad2eb7987f02f7dd002076f65a685730705d04435313b5cf44d3a6923629fb29",
+    "zh:b2145ae7134dba893c7f74ad7dfdc65fdddf6c7b1d0ce7e2f3baa96212322fd8",
+    "zh:bd6bae3ac5c3f96ad9219d3404aa006ef1480e9041d4c95df1808737e37d911b",
+    "zh:e89758b20ae59f1b9a6d32c107b17846ddca9634b868cf8f5c927cbb894b1b1f",
+  ]
+}
+
 provider "registry.opentofu.org/hashicorp/google" {
   version     = "5.37.0"
   constraints = "~> 5.0"

--- a/dnsimple/contacts.tf
+++ b/dnsimple/contacts.tf
@@ -1,0 +1,18 @@
+resource "dnsimple_contact" "ocf" {
+  label      = "Open Collective Foundation"
+  first_name = "Homebrew"
+  last_name  = "Maintainers"
+  email      = "ops@brew.sh"
+
+  phone          = "+1 555 1234"
+  address1       = "123 Homebrew Street"
+  city           = "Homebrew"
+  state_province = "HB"
+  postal_code    = "00001"
+  country        = "United States"
+
+  lifecycle {
+    ignore_changes = [address1, city, state_province, postal_code, phone]
+  }
+
+}

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,10 @@ locals {
   unmanagable_members = ["p-linnane", "issyl0", "colindean", "MikeMcQuaid", "BrewSponsorsBot"]
 }
 
+module "dnsimple" {
+  source = "./dnsimple"
+}
+
 module "github" {
   source              = "./github"
   teams               = var.teams


### PR DESCRIPTION
- Fixes https://github.com/Homebrew/homebrew-user-management/issues/1.
- Set the `DNSIMPLE_ACCOUNT` and `DNSIMPLE_TOKEN` envvars to be able to run this.
- The address here is fake because the address in the actual account is the address of the cardholder that pays the bill (one of the PLC) and we don't want that on the public internet.